### PR TITLE
Ros2 migrate diagnostic aggregator

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 ament_python_install_package(${PROJECT_NAME})
 install(
   TARGETS ${PROJECT_NAME} ${PLUGIN_LIB}
-  DESTINATION lib/${PROJECT_NAME}
+  DESTINATION lib
 )
 
 install(

--- a/diagnostic_aggregator/src/generic_analyzer.cpp
+++ b/diagnostic_aggregator/src/generic_analyzer.cpp
@@ -81,9 +81,9 @@ bool GenericAnalyzer::init(
     "Retrieved %d parameter(s) for prefix '%s'.",
     parameters.size(), breadcrumb_.c_str());
 
-  double timeout;
-  int num_items_expected;
-  bool discard_stale;
+  double timeout = 5.0;
+  int num_items_expected = -1;
+  bool discard_stale = false;
 
   for (const auto & param : parameters) {
     string pname = param.first;


### PR DESCRIPTION
Hi,
Thank you for this effort in porting diagnostics to ROS2.
When trying the demo in ROS eloquent I stumbled upon two issues :
- I couldn't launch the aggregator_node executable because it was unable to locate its shared libraries. Installing these in `lib` instead of `lib/${PROJECT_NAME}` fixes the problem. (same as ROS demos [here](https://github.com/ros2/demos/blob/fab4fc38d5ea589c019659d6a49da4ba9c20594b/image_tools/CMakeLists.txt#L41) )
- Some parameters in the `generic_analyser` were left initialized instead of using their default value. This caused some random behavior when launching aggregator_node on the `demo.yaml` file